### PR TITLE
Fix implicit conversion in string made by numbers.

### DIFF
--- a/src/json2yaml.js
+++ b/src/json2yaml.js
@@ -82,7 +82,9 @@
   }
 
   function normalizeString(str) {
-    if (str.match(/^[\w]+$/)) {
+    if (str.match(/^[\d]+$/)) {
+      return '"' + str + '"';
+    } else if(str.match(/^[\w]+$/)) {
       return str;
     } else {
       return '"'+escape(str).replace(/%u/g,'\\u').replace(/%U/g,'\\U').replace(/%/g,'\\x')+'"';

--- a/test/basic.js
+++ b/test/basic.js
@@ -22,3 +22,4 @@ test({ hello: '#你好， 世界！'});
 test({ hello: '\\你好， 世界！'});
 test({ hello: '"你好， 世界！'});
 test({ hello: '%你好， 世界！'});
+test({ hello: '1' });


### PR DESCRIPTION
When I passed  `{hello: '1'}`, the hello's value should be a string '1' not a number 1, but code will give this:

```
------------------------
TESTING:
{ hello: '1' }
OUTPUT:
hello: 1
------------------------
```
This result isn't I expect, so I make a change.

Signed-off-by: corvofeng <corvofeng@gmail.com>